### PR TITLE
Fix lang_IT handling of floats (#143)

### DIFF
--- a/num2words/lang_IT.py
+++ b/num2words/lang_IT.py
@@ -169,7 +169,7 @@ class Num2Word_IT:
     def to_cardinal(self, number):
         if number < 0:
             string = Num2Word_IT.MINUS_PREFIX_WORD + self.to_cardinal(-number)
-        elif number % 1 != 0:
+        elif isinstance(number, float):
             string = self.float_to_words(number)
         elif number < 20:
             string = CARDINAL_WORDS[number]

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -22,7 +22,6 @@ from num2words import num2words
 
 
 class Num2WordsITTest(TestCase):
-
     maxDiff = None
 
     def test_negative(self):
@@ -224,4 +223,12 @@ class Num2WordsITTest(TestCase):
             "trecentoquarantacinque biliardi, seicentosettantotto bilioni, "
             "novecentouno miliardi, duecentotrentaquattro milioni e "
             "cinquecentosessantasettemilaottocentonovantesimo"
+        )
+
+    def test_with_decimals(self):
+        self.assertAlmostEqual(
+            num2words(1.0, lang="it"), "uno virgola zero"
+        )
+        self.assertAlmostEqual(
+            num2words(1.1, lang="it"), "uno virgola uno"
         )


### PR DESCRIPTION
`n % 1 != 0` is not a valid test for float:

In []: 1.1 % 1 == 0
Out[]: False

but:

In []: 1.0 % 1 == 0
Out[]: True

hence it's really necessary to explicitly test for type in this case.

## Fixes # by...

### Changes proposed in this pull request:

* ...
* ...

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

*Fill out this section so that a reviewer can know how to verify your change.*

### Additional notes

*If applicable, explain the rationale behind your change.*

